### PR TITLE
Fix blossom implosion rescheduling

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cirq==0.7.0
+cirq==0.14.1
 pytest
 pygame
 networkx

--- a/slowmatch/mwpm.py
+++ b/slowmatch/mwpm.py
@@ -86,6 +86,10 @@ class Mwpm:
             b = matches[k + 1]
             self.match_map[a] = b
             self.match_map[b] = a
+            # Set region growth to zero (even though already zero) to ensure
+            # these regions are rescheduled.
+            self.fill_system.set_region_growth(a, new_growth=0)
+            self.fill_system.set_region_growth(b, new_growth=0)
 
         # The odd length path is inserted into the alternating tree.
         ancestor: OuterNode = self.tree_id_map[out_parent_id]

--- a/slowmatch/mwpm_test.py
+++ b/slowmatch/mwpm_test.py
@@ -175,6 +175,14 @@ def test_blossom_implosion():
         ('set_region_growth', 13, -1),
         ('set_region_growth', 11, +1),
         # Blossom imploding.
+        # Region growth of matches set to zero (to ensure they are rescheduled)
+        ('set_region_growth', 10, 0),
+        ('set_region_growth', 0, 0),
+        ('set_region_growth', 1, 0),
+        ('set_region_growth', 2, 0),
+        ('set_region_growth', 3, 0),
+        ('set_region_growth', 4, 0),
+        # Then odd-length path region growth set for outer and inner nodes
         ('set_region_growth', 9, -1),
         ('set_region_growth', 8, +1),
         ('set_region_growth', 7, -1),


### PR DESCRIPTION
This PR fixes an issue where newly formed matches within an imploding blossom aren't rescheduled. It also bumps the cirq version from 0.7 to 0.14.1 to fix an [issue](https://stackoverflow.com/questions/66174862/import-error-cant-import-name-gcd-from-fractions) with the older version of networkx used by cirq 0.7 for python3.9.